### PR TITLE
Allow special chars in app name

### DIFF
--- a/src/rebar_raw_resource.erl
+++ b/src/rebar_raw_resource.erl
@@ -463,7 +463,7 @@ ensure_app(Path, Mod, Name, Opts, Result) ->
                 "%%\n"
                 % this is the minimum set of elements required to make rebar
                 % happy when there are no sources for it to compile
-                "{application,   ~s,\n"
+                "{application,   ~p,\n"
                 "[\n"
                 "    {description,   \"~s\"},\n"
                 "    {vsn,           \"~s\"},\n"


### PR DESCRIPTION
If the app name atom contains special characters ~s would just write it
to the generated .app file while ~p will properly quote it if necessary.

I wonder if this or any other fork is maintained...